### PR TITLE
Support latest IntelliJ

### DIFF
--- a/idea-tower.sh
+++ b/idea-tower.sh
@@ -19,8 +19,8 @@ fi
 MERGING="$4"
 BACKUP="/tmp/$(date +"%Y%d%m%H%M%S")"
 
-APPLICATION_PATH="/Applications/IntelliJ IDEA 15.app"
-CMD="/Applications/IntelliJ IDEA 15.app/Contents/MacOS/idea"
+APPLICATION_PATH="/Applications/IntelliJ IDEA.app"
+CMD="/Applications/IntelliJ IDEA.app/Contents/MacOS/idea"
 
 if [ -n "$MERGING" ]; then
   BASE="$3"

--- a/install.sh
+++ b/install.sh
@@ -1,4 +1,3 @@
 mkdir -p ~/Library/Application\ Support/com.fournova.Tower2/CompareTools
-cp CompareTools.plist ~/Library/Application\ Support/com.fournova.Tower2/CompareTools
-cp idea-tower.sh ~/Library/Application\ Support/com.fournova.Tower2/CompareTools
+cp CompareTools.plist idea-tower.sh ~/Library/Application\ Support/com.fournova.Tower2/CompareTools
 chmod +x ~/Library/Application\ Support/com.fournova.Tower2/CompareTools/idea-tower.sh


### PR DESCRIPTION
Jetbrains no longer use version numbers in the app names for their latest apps.

To fix existing installations run the following:

    sed -ie 's/IntelliJ IDEA 15.app/IntelliJ IDEA.app/g' ~/Library/Application\ Support/com.fournova.Tower2/CompareTools/idea-tower.sh